### PR TITLE
Added polling events

### DIFF
--- a/dggbot/chat.py
+++ b/dggbot/chat.py
@@ -7,7 +7,14 @@ import websocket
 from .event import EventType
 from ._logging import _logger
 from .funcs import threaded
-from .message import Message, MuteMessage, PinnedMessage, PrivateMessage
+from .message import (
+    Message,
+    MuteMessage,
+    PinnedMessage,
+    PollMessage,
+    PrivateMessage,
+    VoteMessage,
+)
 from .user import User
 from .errors import (
     AccountTooYoung,
@@ -67,6 +74,7 @@ class DGGChat:
         )
 
     def _dggtime_to_dt(self, timestamp: str) -> datetime:
+        timestamp = timestamp.replace("+0000", "Z")
         return datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%SZ")
 
     def _dggepoch_to_dt(self, epoch: int) -> datetime:
@@ -147,6 +155,30 @@ class DGGChat:
                 self._dggepoch_to_dt(data["timestamp"]),
                 data.get("data"),
                 data["uuid"],
+            )
+        elif event_type in (EventType.POLLSTART, EventType.POLLSTOP):
+            msg = PollMessage(
+                self,
+                event_type,
+                data["nick"],
+                canvote=data["canvote"],
+                myvote=data["myvote"],
+                weighted=data["weighted"],
+                start=self._dggtime_to_dt(data["start"]),
+                now=self._dggtime_to_dt(data["start"]),
+                # Time comes in milliseconds
+                time=data["time"] // 1000,
+                question=data["question"],
+                options=data["options"],
+                totals=data["totals"],
+                totalvotes=data["totalvotes"],
+            )
+        elif event_type == EventType.VOTECAST:
+            msg = VoteMessage(
+                self,
+                event_type,
+                data["nick"],
+                vote=data["vote"],
             )
         elif event_type in (
             EventType.MESSAGE,
@@ -329,4 +361,22 @@ class DGGChat:
     def on_refresh(self, msg: Message):
         """Do stuff when refreshed."""
         for func in self._events.get("on_refresh", tuple()):
+            func(msg)
+
+    @threaded
+    def on_pollstart(self, msg: PollMessage):
+        """Do stuff when a poll is started."""
+        for func in self._events.get("on_pollstart", tuple()):
+            func(msg)
+
+    @threaded
+    def on_pollstop(self, msg: PollMessage):
+        """Do stuff when a poll is ended."""
+        for func in self._events.get("on_pollstop", tuple()):
+            func(msg)
+
+    @threaded
+    def on_votecast(self, msg: VoteMessage):
+        """Do stuff when a vote is cast in a poll."""
+        for func in self._events.get("on_votecast", tuple()):
             func(msg)

--- a/dggbot/chat.py
+++ b/dggbot/chat.py
@@ -165,7 +165,7 @@ class DGGChat:
                 myvote=data["myvote"],
                 weighted=data["weighted"],
                 start=self._dggtime_to_dt(data["start"]),
-                now=self._dggtime_to_dt(data["start"]),
+                now=self._dggtime_to_dt(data["now"]),
                 # Time comes in milliseconds
                 time=data["time"] // 1000,
                 question=data["question"],
@@ -306,6 +306,12 @@ class DGGChat:
         """Send private message to someone."""
         payload = {"nick": nick, "data": msg}
         self.ws.send(f"PRIVMSG {json.dumps(payload)}")
+
+    @threaded
+    def cast_vote(self, vote: int):
+        """Participate in a chat poll."""
+        payload = {"vote": str(vote)}
+        self.ws.send(f"CASTVOTE {json.dumps(payload)}")
 
     @threaded
     def on_broadcast(self, msg):

--- a/dggbot/event.py
+++ b/dggbot/event.py
@@ -10,6 +10,8 @@ class EventType:
     MUTE = "MUTE"
     NAMES = "NAMES"
     PIN = "PIN"
+    POLLSTART = "POLLSTART"
+    POLLSTOP = "POLLSTOP"
     PRIVMSG = "PRIVMSG"
     PRIVMSGSENT = "PRIVMSGSENT"
     QUIT = "QUIT"
@@ -17,6 +19,7 @@ class EventType:
     SUBONLY = "SUBONLY"
     UNBAN = "UNBAN"
     UNMUTE = "UNMUTE"
+    VOTECAST = "VOTECAST"
 
     @classmethod
     @cache

--- a/dggbot/message.py
+++ b/dggbot/message.py
@@ -2,6 +2,7 @@ import dataclasses
 from datetime import datetime
 from ._logging import _logger
 from .user import User
+from typing import List
 
 
 @dataclasses.dataclass
@@ -45,3 +46,23 @@ class PrivateMessage(Message):
 
     def reply(self, content):
         self.chat.send_privmsg(self.nick, content)
+
+
+@dataclasses.dataclass
+class PollMessage(Message):
+    canvote: bool = None
+    myvote: int = None
+    weighted: bool = None
+    start: datetime = None
+    now: datetime = None
+    # Poll time is in milliseconds
+    time: int = None
+    question: str = None
+    options: List[str] = None
+    totals: List[int] = None
+    totalvotes: int = None
+
+
+@dataclasses.dataclass
+class VoteMessage(Message):
+    vote: str = None

--- a/dggbot/message.py
+++ b/dggbot/message.py
@@ -2,7 +2,6 @@ import dataclasses
 from datetime import datetime
 from ._logging import _logger
 from .user import User
-from typing import List
 
 
 @dataclasses.dataclass
@@ -62,8 +61,8 @@ class PollMessage(_MessageBase):
     # Poll time is in milliseconds
     time: int = None
     question: str = None
-    options: List[str] = None
-    totals: List[int] = None
+    options: list[str] = None
+    totals: list[int] = None
     totalvotes: int = None
 
     def vote(self, option: int):

--- a/dggbot/message.py
+++ b/dggbot/message.py
@@ -53,7 +53,7 @@ class PrivateMessage(Message):
 
 
 @dataclasses.dataclass
-class PollMessage(Message):
+class PollMessage(_MessageBase):
     canvote: bool = None
     myvote: int = None
     weighted: bool = None
@@ -66,7 +66,10 @@ class PollMessage(Message):
     totals: List[int] = None
     totalvotes: int = None
 
+    def vote(self, option: int):
+        self.chat.cast_vote(option)
+
 
 @dataclasses.dataclass
-class VoteMessage(Message):
+class VoteMessage(_MessageBase):
     vote: str = None

--- a/examples/polls.py
+++ b/examples/polls.py
@@ -1,0 +1,28 @@
+from dggbot import DGGBot
+from dggbot.message import PollMessage, Message
+
+
+bot = DGGBot("auth_token")
+
+
+@bot.event()
+def on_pollstart(poll: PollMessage):
+    """Automatically vote YEE in every poll"""
+    if "YEE" in poll.options:
+        poll.vote(poll.options.index("YEE") + 1)
+
+
+@bot.command()
+def vote(msg: Message):
+    """Vote for the first option in a poll"""
+    bot.cast_vote(1)
+
+
+@bot.event()
+def on_pollstop(poll: PollMessage):
+    """Grab the results of a poll"""
+    print(dict(zip(poll.options, poll.totals)))
+
+
+if __name__ == "__main__":
+    bot.run_forever()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dgg-bot"
-version = "0.7.1"
+version = "0.8.0"
 authors = [
     { name="Fritz-02"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dgg-bot"
-version = "0.7.0"
+version = "0.7.1"
 authors = [
     { name="Fritz-02"},
 ]

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="dgg-bot",
-    version="0.7.1",
+    version="0.8.0",
     author="Fritz",
     description="A library for making a bot in Destiny.gg chat.",
     long_description_content_type="text/x-rst",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="dgg-bot",
-    version="0.7.0",
+    version="0.7.1",
     author="Fritz",
     description="A library for making a bot in Destiny.gg chat.",
     long_description_content_type="text/x-rst",


### PR DESCRIPTION
I noticed some new event types for polls when going through my logs

Samples:

> POLLSTART {'canvote': True, 'myvote': 0, 'nick': 'Cake', 'weighted': False, 'start': '2023-02-04T03:13:48+0000', 'now': '2023-02-04T03:13:48+0000', 'time': 30000, 'question': 'can you close vim?', 'options': ['yes', 'no'], 'totals': [0, 0], 'totalvotes': 0}

> VOTECAST {'nick': 'alembic', 'vote': '1'}

> POLLSTOP {'canvote': False, 'myvote': 0, 'nick': 'Cake', 'weighted': False, 'start': '2023-02-04T03:13:48+0000', 'now': '2023-02-04T03:14:18+0000', 'time': 30000, 'question': 'can you close vim?', 'options': ['yes', 'no'], 'totals': [36, 49], 'totalvotes': 85}

Note that the **'start'** and **'now'** timestamps are slightly different from normal DGG timestamps, so I added a quick **replace()** to **_dggtime_to_dt()**

Not yet tested which is why this is a draft at the moment.

PepoTurkey