### PR TITLE
add setup.py requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,4 +22,8 @@ setup(
     ],
     packages=find_packages(),
     python_requires=">=3.9",
+    install_requires=[
+        "requests",
+        "websocket-client",
+    ]
 )


### PR DESCRIPTION
Currently, installing dgg-bot in a new venv does not bring along required dependencies
![image](https://user-images.githubusercontent.com/7504947/218638667-50cb5742-2c63-4d6d-acff-fdd6b281e5fe.png)

Packages should be added to `install_requires` to be installed as a dependency https://packaging.python.org/en/latest/discussions/install-requires-vs-requirements/#id5

This PR adds the current contents of requirements.txt to required dependences and are fetched on install. 
![image](https://user-images.githubusercontent.com/7504947/218639122-d10773d0-e2bf-4668-910a-5f5aca522632.png)
 