### PR TITLE
Improve on_names() event handler

### DIFF
--- a/dggbot/chat.py
+++ b/dggbot/chat.py
@@ -264,11 +264,11 @@ class DGGChat(WSBase):
             user["nick"].lower(): User(
                 user["nick"],
                 self._dggtime_to_dt(user["createdDate"]),
-                self._convert_flairs(user["features"]),
+                self._convert_flairs(user),
             )
             for user in users
         }
-        self.on_event("names", connection_count, users)
+        self.on_event("names", connection_count, self._users)
 
     @threaded
     def send(self, msg: str):

--- a/dggbot/chat.py
+++ b/dggbot/chat.py
@@ -264,7 +264,7 @@ class DGGChat(WSBase):
             user["nick"].lower(): User(
                 user["nick"],
                 self._dggtime_to_dt(user["createdDate"]),
-                user["features"],
+                self._convert_flairs(user["features"]),
             )
             for user in users
         }


### PR DESCRIPTION
* Returns features as a `Flair` object
* Fixes a bug where on_names returns the input list

example bot code:
```Python
bot = DGGBot(wss="wss://chat.pepoturkey.dev/ws")

@bot.event()
def on_names(count, users):
  for user, values in users.items():
    print(user, values.features)
    # tena [Flair<Subscriber Tier 6>, Flair<PepoTurkey Master>]

bot.run_forever()
```